### PR TITLE
feat: include frontmater in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The second one writes a JSON file to disk with metadata for each file name. This
  * JSON export: Metadata[]
  */
 interface Metadata {
+	frontmatter: any; 
 	fileName: string;
 	relativePath: string;
 	tags?: string[];
@@ -72,7 +73,7 @@ The exported array contains a JSON array with `Metadata` objects, one object for
 
 All objects have a `fileName` and a `relativePath`. `fileName` doesn't contain the `.md` extension, `relativePath` is the path from your vault root. 
 
-If a file has tags, the object has a `tags` property that contains an array of tags. Tags are all lower-cased and if a tag appears more than one time in a file, it will only appear one time in `tags`.
+If a file has tags, the object has a `tags` property that contains an array of tags. Tags are all lower-cased and if a tag appears more than one time in a file, it will only appear one time in `tags`. If a file has any frontmatter it is included in `frontmatter`. The structure of the object depends on your frontmatter.
 
 `aliases`, `links` and `backlinks` also only exist if there are any of the in a file.
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,6 +17,7 @@ export interface BridgeSettings {
  * the metadata that will be written to disk as an array of {@link Metadata}
  */
 export interface Metadata {
+	frontmatter: any;
 	fileName: string;
 	relativePath: string;
 	tags?: string[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { MetadataCache } from 'obsidian';
+import type { MetadataCache, FrontMatterCache } from 'obsidian';
 import type Methods from './methods'
 
 export interface BridgeSettings {
@@ -91,4 +91,11 @@ export interface extendedMetadataCache extends MetadataCache {
 	getTags(): {
 		string?: number;
 	};
+}
+
+export interface extendedFrontMatterCache extends FrontMatterCache {
+	tags?: string[];
+	aliases?: string[];
+	cssclass?: string;
+	publish?: boolean;
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,7 +17,7 @@ export interface BridgeSettings {
  * the metadata that will be written to disk as an array of {@link Metadata}
  */
 export interface Metadata {
-	frontmatter: any;
+	frontmatter?: any;
 	fileName: string;
 	relativePath: string;
 	tags?: string[];

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -267,9 +267,9 @@ export default class Methods {
 			}
 
 			if (currentCache.frontmatter) {
+				metaObj.frontmatter = currentCache.frontmatter;
 				//@ts-expect-error, could return null so can't be assigned to current aliases,
 				// check for null is done later
-				metaObj.frontmatter = currentCache.frontmatter;
 				currentAliases = parseFrontMatterAliases(
 					currentCache.frontmatter
 				);

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -11,6 +11,7 @@ import {
 	TFolder,
 	TFile,
 	TAbstractFile,
+	FrontMatterCache,
 } from 'obsidian';
 import type {
 	Metadata,
@@ -103,6 +104,13 @@ export default class Methods {
 				'Metadata Extractor plugin: wrote the allExceptMd JSON file'
 			);
 		}
+	}
+
+
+	createCleanFrontmatter(frontmatter: FrontMatterCache) {
+		delete frontmatter.aliases;  
+		delete frontmatter.tags;
+		return frontmatter;
 	}
 
 
@@ -267,7 +275,7 @@ export default class Methods {
 			}
 
 			if (currentCache.frontmatter) {
-				metaObj.frontmatter = currentCache.frontmatter;
+				metaObj.frontmatter = this.createCleanFrontmatter(currentCache.frontmatter);
 				//@ts-expect-error, could return null so can't be assigned to current aliases,
 				// check for null is done later
 				currentAliases = parseFrontMatterAliases(

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -269,6 +269,7 @@ export default class Methods {
 			if (currentCache.frontmatter) {
 				//@ts-expect-error, could return null so can't be assigned to current aliases,
 				// check for null is done later
+				metaObj.frontmatter = currentCache.frontmatter;
 				currentAliases = parseFrontMatterAliases(
 					currentCache.frontmatter
 				);

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -11,7 +11,7 @@ import {
 	TFolder,
 	TFile,
 	TAbstractFile,
-	FrontMatterCache,
+	,
 } from 'obsidian';
 import type {
 	Metadata,
@@ -24,6 +24,7 @@ import type {
 	file,
 	tagCache,
 	extendedMetadataCache,
+	extendedFrontMatterCache
 } from './interfaces';
 import { writeFile, writeFileSync } from 'fs';
 //@ts-ignore
@@ -107,8 +108,8 @@ export default class Methods {
 	}
 
 
-	createCleanFrontmatter(frontmatter: FrontMatterCache) {
-		delete frontmatter.aliases;  
+	createCleanFrontmatter(frontmatter: extendedFrontMatterCache) {
+		delete frontmatter.aliases; 
 		delete frontmatter.tags;
 		return frontmatter;
 	}


### PR DESCRIPTION
I added the frontmatter object to the metadata. The frontmatter object includes all attributes including any custom attributes defined on the notes by an obsidian user. This should solve #6.  

An export then looks the following: 

```
[
  {
    "fileName": "system design",
    "relativePath": "RESOURCES/computerscience/system design.md",
    "tags": [
      "type/howto",
      "computerscience"
    ],
    "frontmatter": {
      "tags": "type/howto, computerscience",
      "season": "winter",
      "classification": "private",
      "title": "how to design (distributed) systems",
      "aliases": [
        "system architecture",
        "service integration",
        "system integration"
      ],
      "TARGET DECK": "computerscience",
      "position": {
        "start": {
          "line": 0,
          "col": 0,
          "offset": 0
        },
        "end": {
          "line": 7,
          "col": 3,
          "offset": 232
        }
      }
    },
    "aliases": [
      "system architecture",
      "service integration",
      "system integration"
    ],
    "headings": [
      {
        "heading": "Footnotes & Resources",
        "level": 2
      }
    ],
    "links": [
      {
        "link": "rest design",
        "relativePath": "RESOURCES/computerscience/rest design.md"
      },
      {
        "link": "adh api management"
      }
    ]
  },
]

```

