### PR TITLE
Adding support for callout blocks

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -12,6 +12,7 @@ export interface BridgeSettings {
 	consoleLog: boolean;
 	canvasFile: string;
 	canvasPath: string;
+	processCalloutBlocks: boolean;
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,6 +23,7 @@ export interface Metadata {
 	relativePath: string;
 	tags?: string[];
 	headings?: { heading: string; level: number }[];
+	blocks?: { block: string; id: string; type: string}[];
 	aliases?: string[];
 	links?: links[];
 	backlinks?: backlinks[];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export const DEFAULT_SETTINGS: BridgeSettings = {
 	canvasFile: 'canvas.json',
 	writingFrequency: '0',
 	writeFilesOnLaunch: false,
+	processCalloutBlocks: false,
 	consoleLog: false,
 };
 
@@ -205,6 +206,22 @@ export class BridgeSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.consoleLog)
 					.onChange((state) => {
 						this.plugin.settings.consoleLog = state;
+						this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(containerEl)
+			.setName('Process callout blocks')
+			.setDesc(
+				'If enabled, it will process each block-id (ie ^some-id) and if it \
+				corresponds to a callout it will export it as an H6. For now this is \
+				experimental so it works with external tools that process the metadata.'
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.processCalloutBlocks)
+					.onChange((state) => {
+						this.plugin.settings.processCalloutBlocks = state;
 						this.plugin.saveSettings();
 					});
 			});


### PR DESCRIPTION
Obsidian keeps track of block-ids, by storing their first and last line.

With this draft PR, when a block-id represents a callout that has a non-empty title, it will be stored in the metadata.



### Examples
Assume in a file we have:
```markdown
> [!note] Note
> - something
> - something-else
^my-note

> [!note]+ Supports admonition
> - this is expanded by default
^supports-admonition-callouts

> [!note]- Including collapsed callouts
> - this is collapsed by default
^supports-collapsed-callouts
```

**Metadata output for that file will include:**

```json
      {
        "block": "Note",
        "id": "my-note",
        "type": "callout"
      },
      {
        "block": "Supports admonition",
        "id": "supports-admonition-callouts",
        "type": "callout"
      },
      {
        "block": "Including collapsed callouts",
        "id": "supports-collapsed-callouts",
        "type": "callout"
      },
```



